### PR TITLE
Handle updated format of filters list

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -24,8 +24,7 @@ cp vf_transform360.c /usr/local/src/ffmpeg/libavfilter/
 cd /usr/local/src/ffmpeg/
 
 # Register Transform360 in libavfilter (insert before AVBENCH)
-sed -i '/REGISTER_FILTER(ABENCH,/ i\
-REGISTER_FILTER(TRANSFORM360, transform360, vf);' libavfilter/allfilters.c
+sed -i '/extern AVFilter ff_af_abench;/i extern AVFilter ff_vf_transform360;' libavfilter/allfilters.c
 
 # Add Transform360 to libavfilter makefile (insert before ALPHAEXTRACT)
 sed -i '/CONFIG_ALPHAEXTRACT_FILTER/ i\


### PR DESCRIPTION
Since the filter registration list format has changed for `libavfilter`, this fixes the `sed` insertion of Transform360 into the filters list. Before this patch, `ffmpeg -filters` doesn't include `transform360`; afterwards it does.

See also https://github.com/facebook/transform360/issues/59

cc @lindamood